### PR TITLE
Fix typos in ABAP environment generator class

### DIFF
--- a/src/zdmo_cl_fe_travel_generator.clas.abap
+++ b/src/zdmo_cl_fe_travel_generator.clas.abap
@@ -600,7 +600,7 @@ CLASS ZDMO_CL_FE_TRAVEL_GENERATOR IMPLEMENTATION.
 
   METHOD generate_data_generator_class.
 
-    DATA(lo_specification) = mo_draft_tabl_put_opertion->for-clas->add_object(  data_generator_class_name
+    DATA(lo_specification) = mo_draft_tabl_put_operation->for-clas->add_object(  data_generator_class_name
                                   )->set_package( package_name
                                   )->create_form_specification( ).
     lo_specification->set_short_description( |This class generates the test data| ).
@@ -1581,13 +1581,13 @@ CLASS ZDMO_CL_FE_TRAVEL_GENERATOR IMPLEMENTATION.
 
 *   Create data generator class
 
-    mo_draft_tabl_put_opertion = get_put_operation( mo_environment  ).
+    mo_draft_tabl_put_operation = get_put_operation( mo_environment  ).
     generate_data_generator_class(
       EXPORTING
 *        io_put_operation       = put_operation
         lo_transport            = transport
     ).
-    lo_result = mo_draft_tabl_put_opertion->execute( ).
+    lo_result = mo_draft_tabl_put_operation->execute( ).
     " handle findings
     lo_findings = lo_result->findings.
     lt_findings = lo_findings->get( ).

--- a/src/zdmo_cl_fe_travel_generator_op.clas.abap
+++ b/src/zdmo_cl_fe_travel_generator_op.clas.abap
@@ -607,7 +607,7 @@ CLASS ZDMO_CL_FE_TRAVEL_GENERATOR_OP IMPLEMENTATION.
 
   METHOD generate_data_generator_class.
 
-    DATA(lo_specification) = mo_draft_tabl_put_opertion->for-clas->add_object(  data_generator_class_name
+    DATA(lo_specification) = mo_draft_tabl_put_operation->for-clas->add_object(  data_generator_class_name
                                   )->set_package( package_name
                                   )->create_form_specification( ).
     lo_specification->set_short_description( |This class generates the test data| ).
@@ -1588,13 +1588,13 @@ CLASS ZDMO_CL_FE_TRAVEL_GENERATOR_OP IMPLEMENTATION.
 
 *   Create data generator class
 
-    mo_draft_tabl_put_opertion = get_put_operation( mo_environment  ).
+    mo_draft_tabl_put_operation = get_put_operation( mo_environment  ).
     generate_data_generator_class(
       EXPORTING
 *        io_put_operation       = put_operation
         lo_transport            = transport
     ).
-    lo_result = mo_draft_tabl_put_opertion->execute( ).
+    lo_result = mo_draft_tabl_put_operation->execute( ).
     " handle findings
     lo_findings = lo_result->findings.
     lt_findings = lo_findings->get( ).


### PR DESCRIPTION
As in the base class, the variable is named `mo_draft_tabl_put_operation` (see [here](https://github.com/SAP-samples/cloud-abap-rap/blob/abap-environment/src/zdmo_cl_rap_generator_base.clas.abap#L8C12-L8C39)), the sub-classes need to be adjusted from using `mo_draft_tabl_put_opertion`. 